### PR TITLE
415 response for non-application/json content type requests

### DIFF
--- a/flask_pydantic/exceptions.py
+++ b/flask_pydantic/exceptions.py
@@ -14,6 +14,12 @@ class InvalidIterableOfModelsException(BaseFlaskPydanticException):
     pass
 
 
+class JsonBodyParsingError(BaseFlaskPydanticException):
+    """Exception for error occurring during parsing of request body"""
+
+    pass
+
+
 class ManyModelValidationError(BaseFlaskPydanticException):
     """This exception is raised if there is a failure during validation of many
     models in an iterable"""

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ README = (CURRENT_FOLDER / "README.md").read_text()
 
 
 def get_install_requires(
-    req_file: Path = REQUIREMENTS_PATH
+    req_file: Path = REQUIREMENTS_PATH,
 ) -> Generator[str, None, None]:
     with req_file.open("r") as f:
         for line in f:


### PR DESCRIPTION
Requests need to have `application/json` content type for endpoints with specified request body model.

resolves #3 