### PR TITLE
add functionality for array parameters in query

### DIFF
--- a/flask_pydantic/converters.py
+++ b/flask_pydantic/converters.py
@@ -1,0 +1,24 @@
+from typing import Type
+
+from pydantic import BaseModel
+from werkzeug import ImmutableMultiDict
+
+
+def convert_query_params(
+    query_params: ImmutableMultiDict, model: Type[BaseModel]
+) -> dict:
+    """
+    group query parameters into lists if model defines them
+
+    :param query_params: flasks request.args
+    :param model: query parameter's model
+    :return: resulting parameters
+    """
+    return {
+        **query_params,
+        **{
+            key: value
+            for key, value in query_params.to_dict(flat=False).items()
+            if key in model.__fields__ and model.__fields__[key].is_complex()
+        },
+    }

--- a/flask_pydantic/converters.py
+++ b/flask_pydantic/converters.py
@@ -1,7 +1,7 @@
 from typing import Type
 
 from pydantic import BaseModel
-from werkzeug import ImmutableMultiDict
+from werkzeug.datastructures import ImmutableMultiDict
 
 
 def convert_query_params(

--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -4,6 +4,7 @@ from typing import Optional, Callable, TypeVar, Any, Union, Iterable, Type, List
 from flask import request, jsonify, make_response, Response, current_app
 from pydantic import BaseModel, ValidationError
 
+from .converters import convert_query_params
 from .exceptions import (
     InvalidIterableOfModelsException,
     ManyModelValidationError,
@@ -126,7 +127,7 @@ def validate(
         def wrapper(*args, **kwargs):
             q, b, err = None, None, {}
             if query:
-                query_params = request.args
+                query_params = convert_query_params(request.args, query)
                 try:
                     q = query(**query_params)
                 except ValidationError as ve:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -3,7 +3,7 @@ from typing import NamedTuple, Optional, Type, Union, List
 import pytest
 from flask import jsonify
 from pydantic import BaseModel
-from werkzeug import ImmutableMultiDict
+from werkzeug.datastructures import ImmutableMultiDict
 
 from flask_pydantic import validate
 from flask_pydantic.exceptions import (


### PR DESCRIPTION
Added functionality to use list fields in query params.

When using query model
```python
class QueryMode(BaseModel):
    a: List[str]
```

the api call `/whatever_endpoint?a=one&a=two` results in `request.query_params.a` having the value `["one", "two"]`

closes #7 