### PR TITLE
model aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,33 @@ def post(body: BodyModel, query: QueryModel):
 This way, the parsed data will be directly available in `body` and `query`.
 Furthermore, your IDE will be able to correctly type them.
 
+### Model aliases
+
+Pydantic's [alias feature](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator) is natively supported for query and body models.
+To use aliases in response modify response model
+```python
+def modify_key(text: str) -> str:
+    # do whatever you want with model keys
+    return text
+
+
+class MyModel(BaseModel):
+    ...
+    class Config:
+        alias_generator = modify_key
+        allow_population_by_field_name = True
+
+```
+
+and set `response_by_alias=True` in `validate` decorator
+```
+@app.route(...)
+@validate(response_by_alias=True)
+def my_route():
+    ...
+    return MyModel(...)
+```
+
 ### Example app
 
 For more complete examples see [example application](https://github.com/bauerji/flask_pydantic/tree/master/example_app).

--- a/example_app/app.py
+++ b/example_app/app.py
@@ -63,12 +63,7 @@ def post(body: BodyModel, query: QueryModel):
     # save model to DB
     id_ = 3
 
-    return ResponseModel(
-        id=id_,
-        age=query.age,
-        name=body.name,
-        nickname=body.nickname,
-    )
+    return ResponseModel(id=id_, age=query.age, name=body.name, nickname=body.nickname)
 
 
 @app.route("/many", methods=["GET"])

--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -23,14 +23,15 @@ InputParams = TypeVar("InputParams")
 def make_json_response(
     content: Union[BaseModel, Iterable[BaseModel]],
     status_code: int,
+    by_alias: bool,
     exclude_none: bool = False,
     many: bool = False,
 ) -> Response:
     """serializes model, creates JSON response with given status code"""
     if many:
-        js = f"[{', '.join([model.json(exclude_none=exclude_none) for model in content])}]"
+        js = f"[{', '.join([model.json(exclude_none=exclude_none, by_alias=by_alias) for model in content])}]"
     else:
-        js = content.json(exclude_none=exclude_none)
+        js = content.json(exclude_none=exclude_none, by_alias=by_alias)
     response = make_response(js, status_code)
     response.mimetype = "application/json"
     return response
@@ -75,6 +76,7 @@ def validate(
     exclude_none: bool = False,
     response_many: bool = False,
     request_body_many: bool = False,
+    response_by_alias: bool = False,
 ):
     """
     Decorator for route methods which will validate query and body parameters
@@ -186,7 +188,10 @@ def validate(
 
             if isinstance(res, BaseModel):
                 return make_json_response(
-                    res, on_success_status, exclude_none=exclude_none
+                    res,
+                    on_success_status,
+                    exclude_none=exclude_none,
+                    by_alias=response_by_alias,
                 )
 
             if (
@@ -194,7 +199,12 @@ def validate(
                 and len(res) == 2
                 and isinstance(res[0], BaseModel)
             ):
-                return make_json_response(res[0], res[1], exclude_none=exclude_none)
+                return make_json_response(
+                    res[0],
+                    res[1],
+                    exclude_none=exclude_none,
+                    by_alias=response_by_alias,
+                )
 
             return res
 

--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -181,7 +181,11 @@ def validate(
             if response_many:
                 if is_iterable_of_models(res):
                     return make_json_response(
-                        res, on_success_status, exclude_none, True
+                        res,
+                        on_success_status,
+                        by_alias=response_by_alias,
+                        exclude_none=exclude_none,
+                        many=True,
                     )
                 else:
                     raise InvalidIterableOfModelsException(res)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,6 +72,8 @@ def pass_search(
 @pytest.fixture
 def app(posts, response_model, query_model, body_model, post_model):
     app = Flask("test_app")
+    app.config["DEBUG"] = True
+    app.config["TESTING"] = True
 
     @app.route("/search", methods=["POST"])
     @validate(query=query_model, body=body_model)


### PR DESCRIPTION
This PR adds support for Pydantic's [alias feature](https://pydantic-docs.helpmanual.io/usage/model_config/#alias-generator) in response models  (#14 ).

To apply a callable (e. g. to camelcase conversion) to all model keys specify
```
def to_camelcase(text: str) -> str:
    return "".join(chunk.capitalize() for chunk in text.split("_"))

class ResponseModel(BaseModel):
    ...
    class Config:
        alias_generator = to_camelcase
        allow_population_by_field_name = True
```
and set `response_by_alias` parameter of `validate` route decorator to `True`
```
@app.route(...)
@validate(response_by_alias=True)
def route():
    ...
    return ResponseModel(...)
```