### PR TITLE
do not pin specific version of requirements

### DIFF
--- a/requirements/base.pip
+++ b/requirements/base.pip
@@ -1,3 +1,3 @@
-Flask~=1.1.2
-pydantic~=1.7.2
-dataclasses~=0.7; python_version < '3.7'
+Flask
+pydantic>=1.7
+dataclasses>=0.7; python_version < '3.7'

--- a/requirements/test.pip
+++ b/requirements/test.pip
@@ -1,6 +1,6 @@
 -r base.pip
 
-pytest~=6.1.2
+pytest>=6.1.2
 pytest-flask
 pytest-flake8
 pytest-coverage


### PR DESCRIPTION
use `>=` for requirements version rather that `~=`

resolves #29 