### PR TITLE
ignore return-type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ dmypy.json
 
 docker-compose.yaml
 .dockerignore
+.idea/

--- a/flask_pydantic/core.py
+++ b/flask_pydantic/core.py
@@ -79,7 +79,7 @@ def validate_path_params(func: Callable, kwargs: dict) -> Tuple[dict, list]:
     errors = []
     validated = {}
     for name, type_ in func.__annotations__.items():
-        if name in {"query", "body"}:
+        if name in {"query", "body", "return"}:
             continue
         try:
             value = parse_obj_as(type_, kwargs.get(name))


### PR DESCRIPTION
This fixes an issue where any function with return-type annotations will get processed through `parse_obj_as`, and inevitably throw a validation exception, which will be returned as a very confusing error message where the "loc" property is "return".